### PR TITLE
Handle Google ID token/code exchange and clear user on logout in auth context

### DIFF
--- a/frontend/mealagent-mobile/context/authContext.tsx
+++ b/frontend/mealagent-mobile/context/authContext.tsx
@@ -78,20 +78,23 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     const logout = async () => {
         await clearToken();
         setToken(null);
+        setUser(null);
     };
 
-    const { loginWithGoogle, request } = useGoogleLogin();
+    const { loginWithGoogle } = useGoogleLogin();
 
     const loginGoogle = async () => {
         const t = await loginWithGoogle();
         await saveToken(t);
         setToken(t);
+        await loadUser(t);
     };
 
     const loginApple = async () => {
         const t = await loginWithApple();
         await saveToken(t);
         setToken(t);
+        await loadUser(t);
     };
 
     const reloadUser = async () => {
@@ -101,10 +104,9 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     };
 
     return (
-        <AuthContext.Provider value={{
-            token, loading, login, register, logout,
-            loginApple, loginGoogle, user, reloadUser
-        }}>
+        <AuthContext.Provider
+            value={{ token, loading, login, register, logout, loginApple, loginGoogle, user, reloadUser }}
+        >
             {children}
         </AuthContext.Provider>
     );

--- a/frontend/mealagent-mobile/services/auth/google.ts
+++ b/frontend/mealagent-mobile/services/auth/google.ts
@@ -1,3 +1,4 @@
+import * as AuthSession from "expo-auth-session";
 import * as Google from "expo-auth-session/providers/google";
 import * as WebBrowser from "expo-web-browser";
 import { api } from "../api";
@@ -5,9 +6,10 @@ import { api } from "../api";
 WebBrowser.maybeCompleteAuthSession();
 
 export function useGoogleLogin() {
-    const [request, response, promptAsync] = Google.useAuthRequest({
+    const [request, , promptAsync] = Google.useIdTokenAuthRequest({
         webClientId: process.env.EXPO_PUBLIC_GOOGLE_CLIENT_ID,
         iosClientId: process.env.EXPO_PUBLIC_GOOGLE_IOS_CLIENT_ID,
+        androidClientId: process.env.EXPO_PUBLIC_GOOGLE_ANDROID_CLIENT_ID,
         scopes: ["openid", "profile", "email"],
     });
 
@@ -18,7 +20,35 @@ export function useGoogleLogin() {
             throw new Error("Google login cancelled");
         }
 
-        const idToken = result.authentication?.idToken;
+        let idToken =
+            ("params" in result && typeof result.params?.id_token === "string"
+                ? result.params.id_token
+                : undefined) ?? result.authentication?.idToken;
+
+        const authCode =
+            "params" in result && typeof result.params?.code === "string"
+                ? result.params.code
+                : undefined;
+
+        if (!idToken && authCode && request?.codeVerifier) {
+            const exchangeClientId = request.clientId;
+
+            if (!exchangeClientId) {
+                throw new Error("Google client ID is not configured for code exchange");
+            }
+
+            const tokenResponse = await AuthSession.exchangeCodeAsync(
+                {
+                    clientId: exchangeClientId,
+                    code: authCode,
+                    redirectUri: request.redirectUri,
+                    extraParams: { code_verifier: request.codeVerifier },
+                },
+                Google.discovery
+            );
+
+            idToken = tokenResponse.idToken ?? undefined;
+        }
 
         if (!idToken) {
             throw new Error("No Google ID token returned");


### PR DESCRIPTION
### Motivation
- Ensure Google sign-in works across platforms by handling both ID token and authorization-code flows and exchanging codes when necessary.
- Keep auth state consistent by clearing the `user` on logout and reloading user data after social logins.

### Description
- Replaced `Google.useAuthRequest` with `Google.useIdTokenAuthRequest` and added `expo-auth-session` exchange logic to obtain an ID token from an auth code when needed. 
- Extracted `idToken` robustly from `result.params` or `result.authentication` and implemented a PKCE code exchange via `AuthSession.exchangeCodeAsync` when only an auth code is returned.
- Added `androidClientId` to the Google auth request and updated imports accordingly.
- Updated `AuthProvider` to call `loadUser` after Google/Apple logins and to `setUser(null)` on `logout`, and removed an unused `request` destructure; also reformatted the provider value object.

### Testing
- Ran TypeScript compilation with `yarn tsc`, which completed successfully.
- Ran linting with `yarn lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a246759f70832ba20cf632e84dc5f7)